### PR TITLE
Fix the RNN encoder [Bug #12 and #13]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ __pycache__
 
 *.pth
 *live.ipynb
+*.log
 
 /output
 /output/**
+
+

--- a/configs/default.py
+++ b/configs/default.py
@@ -40,12 +40,14 @@ default_config = dict(
         update_post_train=1, # how often to resample the context when collecting data during training (in trajectories)
         num_exp_traj_eval=1, # how many exploration trajs to collect before beginning posterior sampling at test time
         recurrent=False, # recurrent or permutation-invariant encoder
+        use_traj_context=False, # use traj or tran as the context
         dump_eval_paths=False, # whether to save evaluation trajectories
     ),
     util_params=dict(
         base_log_dir='output',
         use_gpu=True,
         gpu_id=0,
+        seed=0,
         debug=False, # debugging triggers printing and writes logs to debug directory
         docker=False, # TODO docker is not yet supported
     )

--- a/rlkit/core/rl_algorithm.py
+++ b/rlkit/core/rl_algorithm.py
@@ -231,7 +231,8 @@ class MetaRLAlgorithm(metaclass=abc.ABCMeta):
         gt.stamp('sample')
 
     def _try_to_eval(self, epoch):
-        logger.save_extra_data(self.get_extra_data_to_save(epoch))
+        if (epoch+1) % 50 == 0: ## save RB every 50 epochs
+            logger.save_extra_data(self.get_extra_data_to_save(epoch))
         if self._can_evaluate():
             self.evaluate(epoch)
 
@@ -417,7 +418,9 @@ class MetaRLAlgorithm(metaclass=abc.ABCMeta):
         for idx in indices:
             self.task_idx = idx
             self.env.reset_task(idx)
+            self.agent.clear_z() ## I add this!!
             paths = []
+
             for _ in range(self.num_steps_per_eval // self.max_path_length):
                 context = self.sample_context(idx)
                 self.agent.infer_posterior(context)

--- a/rlkit/core/rl_algorithm.py
+++ b/rlkit/core/rl_algorithm.py
@@ -418,7 +418,7 @@ class MetaRLAlgorithm(metaclass=abc.ABCMeta):
         for idx in indices:
             self.task_idx = idx
             self.env.reset_task(idx)
-            self.agent.clear_z() ## I add this!!
+            self.agent.clear_z() ## I add this which make rnn encoder works!
             paths = []
 
             for _ in range(self.num_steps_per_eval // self.max_path_length):
@@ -461,8 +461,8 @@ class MetaRLAlgorithm(metaclass=abc.ABCMeta):
         self.eval_statistics['AverageTrainReturn_all_train_tasks'] = train_returns
         self.eval_statistics['AverageReturn_all_train_tasks'] = avg_train_return
         self.eval_statistics['AverageReturn_all_test_tasks'] = avg_test_return
-        logger.save_extra_data(avg_train_online_return, path='online-train-epoch{}'.format(epoch))
-        logger.save_extra_data(avg_test_online_return, path='online-test-epoch{}'.format(epoch))
+        # logger.save_extra_data(avg_train_online_return, path='online-train-epoch{}'.format(epoch))
+        # logger.save_extra_data(avg_test_online_return, path='online-test-epoch{}'.format(epoch))
 
         for key, value in self.eval_statistics.items():
             logger.record_tabular(key, value)

--- a/rlkit/data_management/simple_replay_buffer.py
+++ b/rlkit/data_management/simple_replay_buffer.py
@@ -10,16 +10,16 @@ class SimpleReplayBuffer(ReplayBuffer):
         self._observation_dim = observation_dim
         self._action_dim = action_dim
         self._max_replay_buffer_size = max_replay_buffer_size
-        self._observations = np.zeros((max_replay_buffer_size, observation_dim))
+        self._observations = np.zeros((max_replay_buffer_size, observation_dim), dtype=np.float32)
         # It's a bit memory inefficient to save the observations twice,
         # but it makes the code *much* easier since you no longer have to
         # worry about termination conditions.
-        self._next_obs = np.zeros((max_replay_buffer_size, observation_dim))
-        self._actions = np.zeros((max_replay_buffer_size, action_dim))
+        self._next_obs = np.zeros((max_replay_buffer_size, observation_dim), dtype=np.float32)
+        self._actions = np.zeros((max_replay_buffer_size, action_dim), dtype=np.float32)
         # Make everything a 2D np array to make it easier for other code to
         # reason about the shape of the data
-        self._rewards = np.zeros((max_replay_buffer_size, 1))
-        self._sparse_rewards = np.zeros((max_replay_buffer_size, 1))
+        self._rewards = np.zeros((max_replay_buffer_size, 1), dtype=np.float32)
+        self._sparse_rewards = np.zeros((max_replay_buffer_size, 1), dtype=np.float32)
         # self._terminals[i] = a terminal was received at time i
         self._terminals = np.zeros((max_replay_buffer_size, 1), dtype='uint8')
         self.clear()
@@ -76,7 +76,7 @@ class SimpleReplayBuffer(ReplayBuffer):
         indices = []
         while len(indices) < batch_size:
             # TODO hack to not deal with wrapping episodes, just don't take the last one
-            start = np.random.choice(self.episode_starts[:-1])
+            start = np.random.choice(self._episode_starts[:-1]) ## previous one is self.episode_starts which should be a typo
             pos_idx = self._episode_starts.index(start)
             indices += list(range(start, self._episode_starts[pos_idx + 1]))
             i += 1

--- a/rlkit/torch/sac/sac.py
+++ b/rlkit/torch/sac/sac.py
@@ -29,6 +29,7 @@ class PEARLSoftActorCritic(MetaRLAlgorithm):
             policy_pre_activation_weight=0.,
             optimizer_class=optim.Adam,
             recurrent=False,
+            use_traj_context=False,
             use_information_bottleneck=True,
             use_next_obs_in_context=False,
             sparse_rewards=False,
@@ -54,6 +55,7 @@ class PEARLSoftActorCritic(MetaRLAlgorithm):
         self.render_eval_paths = render_eval_paths
 
         self.recurrent = recurrent
+        self.use_traj_context = use_traj_context 
         self.latent_dim = latent_dim
         self.qf_criterion = nn.MSELoss()
         self.vf_criterion = nn.MSELoss()
@@ -133,7 +135,7 @@ class PEARLSoftActorCritic(MetaRLAlgorithm):
         # make method work given a single task index
         if not hasattr(indices, '__iter__'):
             indices = [indices]
-        batches = [ptu.np_to_pytorch_batch(self.enc_replay_buffer.random_batch(idx, batch_size=self.embedding_batch_size, sequence=self.recurrent)) for idx in indices]
+        batches = [ptu.np_to_pytorch_batch(self.enc_replay_buffer.random_batch(idx, batch_size=self.embedding_batch_size, sequence=self.use_traj_context)) for idx in indices]
         context = [self.unpack_batch(batch, sparse_reward=self.sparse_rewards) for batch in batches]
         # group like elements together
         context = [[x[i] for x in context] for i in range(len(context[0]))]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,14 @@
+# run this file through 'sh run.sh' in the terminal
+
+# nohup python -u launch_experiment.py ./configs/cheetah-dir.json --rnn --tran --gpu_id=0 --seed=0 > pearl-cheetah-dir-rnn-tran-sd0.log 2>&1 &
+nohup python -u launch_experiment.py ./configs/cheetah-dir.json --rnn --tran --gpu_id=0 --seed=1 > pearl-cheetah-dir-rnn-tran-sd1.log 2>&1 &
+nohup python -u launch_experiment.py ./configs/cheetah-dir.json --rnn --tran --gpu_id=0 --seed=10 > pearl-cheetah-dir-rnn-tran-sd10.log 2>&1 &
+
+
+# nohup python -u launch_experiment.py ./configs/cheetah-dir.json --rnn --traj --gpu_id=1 > pearl-cheetah-dir-rnn-traj.log 2>&1 &
+# nohup python -u launch_experiment.py ./configs/cheetah-dir.json --rnn --traj --gpu_id=1 --seed=1 > pearl-cheetah-dir-rnn-traj-sd1.log 2>&1 &
+# nohup python -u launch_experiment.py ./configs/cheetah-dir.json --rnn --traj --gpu_id=1 --seed=10 > pearl-cheetah-dir-rnn-traj-sd10.log 2>&1 &
+
+# nohup python -u launch_experiment.py ./configs/cheetah-dir.json --mlp --tran --gpu_id=0 > pearl-cheetah-dir-mlp-tran.log 2>&1 &
+
+# nohup python -u launch_experiment.py ./configs/cheetah-dir.json --mlp --traj --gpu_id=0 > pearl-cheetah-dir-mlp-traj.log 2>&1 &


### PR DESCRIPTION
    modified:   rlkit/core/rl_algorithm.py

By adding `self.agent.clear_z()` after https://github.com/katerakelly/oyster/blob/44e20fddf181d8ca3852bdf9b6927d6b8c6f48fc/rlkit/core/rl_algorithm.py#L419 
RNN hidden state will be reset and corresponds to the one task set in the [`evaluate` fun](https://github.com/katerakelly/oyster/blob/44e20fddf181d8ca3852bdf9b6927d6b8c6f48fc/rlkit/core/rl_algorithm.py#L397).

    modified:   launch_experiment.py

I add two click.option, which allows you to run the PEARL with *rnn/mlp* encoder network and *traj/tran* context.

I also add a seed option to launch experiments with different seeds. The default one is 0.

    modified:   rlkit/launchers/launcher_util.py

I restructure the output file by adding *rnn/mlp, traj/tran and seed* options in the exp name file. For example,
The previous result path is: output/cheetah-dir/2022_11_30_08_07_43 
The current one: output/cheetah-dir/2022_11_30_08_28_57-rnn-tran-sd1

    new file:   run.sh

If you want to run experiments, just check and run the **run.sh**.

Changes to be committed:
	modified:   .gitignore
	modified:   configs/default.py
	modified:   launch_experiment.py
	modified:   rlkit/core/rl_algorithm.py
	modified:   rlkit/data_management/simple_replay_buffer.py
	modified:   rlkit/launchers/launcher_util.py
	modified:   rlkit/torch/sac/sac.py
	new file:   run.sh